### PR TITLE
use absolute path for require autoload

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -2,7 +2,7 @@
 
 /** @var rex_addon $this */
 
-require_once 'vendor/autoload.php';
+require_once __DIR__.'vendor/autoload.php';
 
 if (rex::isBackend() && is_object(rex::getUser())) {
     rex_perm::register('cropper[]');


### PR DESCRIPTION
es kam bei mir zu Problemen, wenn ich im redaxo root auch dependencies im vendor installiert habe.
Dadurch, dass der die globale autoload required, wurden auch allen functions versucht erneut zu deklarieren. 

**ErrorException:** Cannot redeclare rex_escape() (previously declared in /Users/marcel/Sites/redaxo/redaxo/redaxo/src/core/functions/function_rex_escape.php:33)
**File:** redaxo/src/core/functions/function_rex_escape.php
**Line:** 33
