### PR TITLE
Abmessungen & Link in Medialist

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -51,4 +51,39 @@ if (rex::isBackend() && rex::getUser()) {
         }
     });
 
+    rex_extension::register( 'MEDIA_LIST_FUNCTIONS', function( rex_extension_point $ep ){
+
+
+
+        if (!rex::getUser()->hasPerm('cropper[]')) return false; // don't show the button
+
+        /** @var rex_sql $media */
+        $media = $ep->getParam('media');
+
+
+        $msg = rex_request::request('cropper_msg', 'string', null);
+        $cropper_error = rex_request::request('cropper_error', 'boolean', false);
+
+        if (!is_null($msg)) {
+            echo ($cropper_error) ? rex_view::error(rex_i18n::msg($msg)) : rex_view::success(rex_i18n::msg($msg));
+        }
+
+        /** @var rex_media $rexMedia */
+        $rexMedia = rex_media::get($media->getValue('name'));
+
+        if ($rexMedia instanceof rex_media && $rexMedia->isImage()) {
+
+            $link = rex_url::backendPage('mediapool/cropper', array(
+                'rex_file_category' => rex_request::get('rex_file_category', 'integer', 0),
+                'file_id' => $ep->getParam('id'),
+                'media_name' => $media->getValue('name'),
+            ), true);
+
+            return '<a href="' . $link . '"><span>' . rex_i18n::msg('cropper_media_edit_link') . '</span> <i class="fa fa-crop"></i></a>';
+        }
+
+    });
+
+
+
 }

--- a/lib/Cropper/CropperExecutor.php
+++ b/lib/Cropper/CropperExecutor.php
@@ -183,6 +183,8 @@ class CropperExecutor
             $this->zebraImage->crop($this->parameter['x'], $this->parameter['y'], ($this->parameter['x'] + $this->parameter['width']), ($this->parameter['y'] + $this->parameter['height']));
             $zebraErrors[] = $this->zebraImage->error;
         }
+        $imgwidth=$this->parameter['width'];
+        $imgheight=$this->parameter['height'];
 
         rex_media_cache::delete($media->getFileName());
         rex_media_manager::deleteCache(pathinfo($media->getFileName(), PATHINFO_FILENAME));
@@ -196,6 +198,17 @@ class CropperExecutor
 
         $result = rex_mediapool_updateMedia(array('name' => 'none'), $FILEINFOS, rex::getUser()->getValue('login'));
         $msgType = ($this->update) ? 'updated' : 'created';
+
+        // Abmessungen abspeichern
+        $sql = rex_sql::factory();
+        $sql->setTable(rex::getTablePrefix() . 'media');
+        $sql->setWhere(['id' => $media->getId()]);
+        $sql->setValue('filesize', filesize(rex_path::media($media->getFileName())));
+        $sql->setValue('width', $imgwidth);
+        $sql->setValue('height', $imgheight);
+        $sql->addGlobalUpdateFields(rex::getUser()->getValue('login'));
+        $sql->update();
+
 
         if (isset($result['ok']) && $result['ok'] == 1 && isset($result['filename'])) {
             $media = rex_media::get($result['filename']);


### PR DESCRIPTION
Fix for #23 (Gecropptes Medium behält alte Abmaße Höhe/Breite statt zugeschnittene Maße) 
New "Feature": #8 (Bearbeiten-Link in Medialist)