### PR TITLE
Edit Link und Übernehmen-Button

### DIFF
--- a/boot.php
+++ b/boot.php
@@ -59,9 +59,9 @@ if (rex::isBackend() && rex::getUser()) {
 
     rex_extension::register( 'MEDIA_LIST_FUNCTIONS', function( rex_extension_point $ep ){
 
-
-
         if (!rex::getUser()->hasPerm('cropper[]')) return false; // don't show the button
+
+        $subject = $ep->getSubject();
 
         /** @var rex_sql $media */
         $media = $ep->getParam('media');
@@ -90,7 +90,11 @@ if (rex::isBackend() && rex::getUser()) {
 
             $link = rex_url::backendPage('mediapool/cropper', $linkParams, true);
 
-            return '<a href="' . $link . '"><span>' . rex_i18n::msg('cropper_media_edit_link') . '</span> <i class="fa fa-crop"></i></a>';
+            // a bit dirty, but it works...
+            return '<a href="' . $link . '"><span>' . rex_i18n::msg('cropper_media_edit_link') . '</span> <i class="fa fa-crop"></i></a>' .
+                '</td>' .
+                '<td class="rex-table-action">' .
+                $subject;
         }
 
     });

--- a/boot.php
+++ b/boot.php
@@ -36,12 +36,17 @@ if (rex::isBackend() && rex::getUser()) {
         $rexMedia = rex_media::get($media->getValue('filename'));
 
         if ($rexMedia instanceof rex_media && $rexMedia->isImage()) {
-
-            $link = rex_url::backendPage('mediapool/cropper', array(
+            $linkParams = array(
                 'rex_file_category' => rex_request::get('rex_file_category', 'integer', 0),
                 'file_id' => $ep->getParam('id'),
                 'media_name' => $media->getValue('filename'),
-            ), true);
+            );
+
+            if (rex_get('opener_input_field', 'string')) {
+                $linkParams['opener_input_field'] = rex_get('opener_input_field', 'string');
+            }
+
+            $link = rex_url::backendPage('mediapool/cropper', $linkParams, true);
 
             $fragment = new rex_fragment();
             $fragment->setVar('elements', array(array(
@@ -73,12 +78,17 @@ if (rex::isBackend() && rex::getUser()) {
         $rexMedia = rex_media::get($media->getValue('name'));
 
         if ($rexMedia instanceof rex_media && $rexMedia->isImage()) {
-
-            $link = rex_url::backendPage('mediapool/cropper', array(
+            $linkParams = array(
                 'rex_file_category' => rex_request::get('rex_file_category', 'integer', 0),
                 'file_id' => $ep->getParam('id'),
                 'media_name' => $media->getValue('name'),
-            ), true);
+            );
+
+            if (rex_get('opener_input_field', 'string')) {
+                $linkParams['opener_input_field'] = rex_get('opener_input_field', 'string');
+            }
+
+            $link = rex_url::backendPage('mediapool/cropper', $linkParams, true);
 
             return '<a href="' . $link . '"><span>' . rex_i18n::msg('cropper_media_edit_link') . '</span> <i class="fa fa-crop"></i></a>';
         }

--- a/boot.php
+++ b/boot.php
@@ -63,6 +63,10 @@ if (rex::isBackend() && rex::getUser()) {
 
         $subject = $ep->getSubject();
 
+        if ($this->getConfig('hide_edit_in_list') !== null) {
+            return $subject;
+        }
+
         /** @var rex_sql $media */
         $media = $ep->getParam('media');
 

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -12,3 +12,5 @@ cropper_media_edit_label = Cropper
 cropper_save_options = Speicheroption
 cropper_successful_updated = Datei wurde erfolgreich aktualisiert!
 cropper_successful_created = Datei wurde erfolgreich erstellt!
+cropper_settings_hide_edit_in_list = Bearbeiten-Link in der Medienliste ausblenden
+cropper_settings_hide = Bearbeiten-Link ausblenden

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -11,3 +11,5 @@ cropper_media_edit_label = Cropper
 cropper_save_options = Saving options
 cropper_successful_updated = File successfully updated!
 cropper_successful_created = File successfully created!
+cropper_settings_hide_edit_in_list = Show Edit-Link in Media List
+cropper_settings_hide = Hi de Edit-Link

--- a/pages/mediapool.cropper.php
+++ b/pages/mediapool.cropper.php
@@ -41,6 +41,11 @@ try {
             $media = ($result['media'] instanceof rex_media) ? $result['media'] : null;
             $urlParameter['file_id'] = $media->getId();
             $urlParameter['cropper_msg'] = $result['msg'];
+
+            if (rex_post('opener_input_field', 'string')) {
+                $urlParameter['opener_input_field'] = rex_post('opener_input_field', 'string');
+            }
+
             rex_response::sendRedirect(rex_url::backendPage(POOL_MEDIA, $urlParameter, false));
         } else {
             // don't jump stay and get error msg
@@ -241,6 +246,7 @@ try {
             <input type="hidden" name="file_id" value="' . rex_request::request('file_id', 'integer') . '" />
             <input type="hidden" name="media_name" value="' . $mediaName . '" />
             <input type="hidden" name="rex_file_category" value="' . rex_request::request('rex_file_category', 'integer') . '" />
+            <input type="hidden" name="opener_input_field" value="' . rex_request::request('opener_input_field', 'string') . '" />
             ' . $panel . $buttons . '
         </form>';
     }

--- a/pages/settings.php
+++ b/pages/settings.php
@@ -12,6 +12,9 @@ $form = rex_config_form::factory('cropper');
 $field = $form->addTextAreaField('aspect_ratios', null,['class' => 'form-control']);
 $field->setLabel($addon->i18n('cropper_settings_aspect_ratios'));
 
+$field = $form->addCheckboxField('hide_edit_in_list');
+$field->setLabel($addon->i18n('cropper_settings_hide'));
+$field->addOption($addon->i18n('cropper_settings_hide_edit_in_list'), 1);
 
 // Ausgabe des Formulars
 $fragment = new rex_fragment();


### PR DESCRIPTION
Übernehmen-Button wird wieder angezeigt.
Bearbeite-Link kann in den Einstellungen ausgeblendet werden.
Ein fix für den Übernehmen Button ist noch dabei, das ist zwar nicht schön, geht allerdings nicht anders.

close #17 close #39 