### PR TITLE
Entfernung Checkbox für "Als neue Datei speichern" falls checked&disabled

### DIFF
--- a/assets/css/cropper.css
+++ b/assets/css/cropper.css
@@ -597,3 +597,6 @@ Release Dtae : 15 November, 2017
     transition: border 0.4s ease 0s, box-shadow 0.4s ease 0s, background-color 1.2s ease 0s;
     cursor: not-allowed;
 }
+
+
+.nocheckbox {padding-top: 7px;}

--- a/lang/de_de.lang
+++ b/lang/de_de.lang
@@ -4,6 +4,7 @@ cropper_settings_aspect_ratios = Seitenverhältnisse
 cropper_settings = Einstellungen
 cropper_media_crop_title = Bild "%s" zuschneiden
 cropper_img_save_info = Resultat der Bearbeitung als neue Datei speichern
+cropper_img_save_info_nochoice = Das Resultat der Bearbeitung wird als neue Datei gespeichert.
 cropper_jpg_quality = JPEG Qualität
 cropper_png_compression = PNG Kompression
 cropper_back_to_media = Zurück

--- a/lang/en_gb.lang
+++ b/lang/en_gb.lang
@@ -3,6 +3,7 @@ cropper_settings_aspect_ratios = Aspect Ratios
 cropper_settings = Settings
 cropper_media_crop_title = Crop image "%s"
 cropper_img_save_info = Save resulting image as a new media file
+cropper_img_save_info_nochoice = The result of the editing is saved as a new file.
 cropper_jpg_quality = JPEG quality
 cropper_png_compression= PNG compression
 cropper_back_to_media = Back

--- a/lang/es_es.lang
+++ b/lang/es_es.lang
@@ -3,6 +3,7 @@ cropper_settings_aspect_ratios = Relaciones de aspecto
 cropper_settings = Ajustes
 cropper_media_crop_title = Recortar imagen "%s"
 cropper_img_save_info = Guarde el resultado de la edición como un nuevo archivo multimedia.
+cropper_img_save_info_nochoice = El resultado de la edición se guarda como un nuevo archivo.
 cropper_jpg_quality = Calidad JPEG
 cropper_png_compression= Compresión PNG
 cropper_back_to_media = Atrás

--- a/lang/sv_se.lang
+++ b/lang/sv_se.lang
@@ -3,6 +3,7 @@ cropper_settings_aspect_ratios = Bildförhållande
 cropper_settings = Inställningar
 cropper_media_crop_title = Beskära bilden "%s"
 cropper_img_save_info = Spara resultatet av redigering som en ny mediefil
+cropper_img_save_info_nochoice = Resultatet av redigeringen sparas som en ny fil.
 cropper_jpg_quality = JPEG kvalité
 cropper_png_compression= PNG kompression
 cropper_back_to_media = Tillbaka

--- a/pages/mediapool.cropper.php
+++ b/pages/mediapool.cropper.php
@@ -145,19 +145,18 @@ try {
 
         // FORM ELEMENTS
         // SAVE OPTION
-        $checkbox = '<input type="checkbox" name="create_new_image" id="create_new_image" checked />';
+        $checkbox = '
+            <label class="checkbox-inline checbox-switch switch-primary">
+                <input type="checkbox" name="create_new_image" id="create_new_image" checked />
+            <span></span>' . rex_i18n::msg('cropper_img_save_info') . '</label>';
         if (!rex::getUser()->hasPerm('cropper[overwrite]')) :
-            $checkbox = '<input type="checkbox" name="create_new_image_cb" id="create_new_image_cb" disabled checked />
-                            <input type="hidden" name="create_new_image" id="create_new_image" value="on">';
+            $checkbox =  '<div class="nocheckbox">' . rex_i18n::msg('cropper_img_save_info_nochoice') .'</div>';
         endif;
         $fragment = new rex_fragment();
         $fragment->setVar('elements', array(
             array(
                 'label' => '<label for="rex-mediapool-title">' . rex_i18n::msg('cropper_save_options') . '</label>',
-                'field' => '<label class="checkbox-inline checbox-switch switch-primary">
-                                '.$checkbox.'
-                                <span></span>' . rex_i18n::msg('cropper_img_save_info') . '
-                            </label>',
+                'field' => $checkbox,
             ),
         ), false);
         $panel .= $fragment->parse('core/form/form.php');


### PR DESCRIPTION
Checkbox kann als "normaler" Redakteur ohne Überschreiben-Rechte nicht betätigt werden. Führt im Betrieb zu Rückfragen. Deshalb wird sie durch einen Informationstext "Das Resultat der Bearbeitung wird als neue Datei gespeichert." ersetzt.