### PR TITLE
Bugfix: Überschreiben von Originaldatei durch Redakteure

### DIFF
--- a/package.yml
+++ b/package.yml
@@ -1,5 +1,5 @@
 package: cropper
-version: '2.0.2'
+version: '2.0.3'
 author: Friends Of REDAXO
 supportpage: https://github.com/FriendsOfREDAXO/cropper
 

--- a/pages/mediapool.cropper.php
+++ b/pages/mediapool.cropper.php
@@ -150,7 +150,7 @@ try {
                 <input type="checkbox" name="create_new_image" id="create_new_image" checked />
             <span></span>' . rex_i18n::msg('cropper_img_save_info') . '</label>';
         if (!rex::getUser()->hasPerm('cropper[overwrite]')) :
-            $checkbox =  '<div class="nocheckbox">' . rex_i18n::msg('cropper_img_save_info_nochoice') .'</div>';
+            $checkbox =  '<div class="nocheckbox"><input type="hidden" name="create_new_image" value="1" />' . rex_i18n::msg('cropper_img_save_info_nochoice') .'</div>';
         endif;
         $fragment = new rex_fragment();
         $fragment->setVar('elements', array(


### PR DESCRIPTION
Fix: Als Redakteur wurde immer die Originaldatei überschrieben, obwohl nur Recht für "Resultat der Bearbeitung als neue Datei speichern" gesetzt war.