### PR TITLE
Namespace geändert in FriendsOfRedaxo\Cropper

### DIFF
--- a/lib/Cropper/CropperExecutor.php
+++ b/lib/Cropper/CropperExecutor.php
@@ -1,68 +1,55 @@
 <?php
+
 /**
  * User: joachimdoerr
  * Date: 2019-02-17
- * Time: 10:48
+ * Time: 10:48.
  * @package Cropper
  */
 
-namespace Cropper;
+namespace FriendsOfRedaxo\Cropper\Cropper;
 
+use Exception;
+use InvalidArgumentException;
 use rex;
 use rex_media;
 use rex_media_cache;
 use rex_media_manager;
 use rex_path;
 use rex_sql;
-use stefangabos\Zebra_Image\Zebra_Image; // Import the Zebra_Image class
+use rex_sql_exception;
+use stefangabos\Zebra_Image\Zebra_Image;
 
-class CroppingException extends \Exception {}
+use const PATHINFO_EXTENSION;
+use const PATHINFO_FILENAME;
+
+ // Import the Zebra_Image class
+
+class CroppingException extends Exception {}
 
 class CropperExecutor
 {
-    const MSG_SUCCESSFUL_CREATED = 'cropper_successful_created';
-    const MSG_SUCCESSFUL_UPDATED = 'cropper_successful_updated';
-    const MSG_FAILED_CREATED = 'cropper_failed_created';
-    const MSG_FAILED_UPDATED = 'cropper_failed_updated';
+    public const MSG_SUCCESSFUL_CREATED = 'cropper_successful_created';
+    public const MSG_SUCCESSFUL_UPDATED = 'cropper_successful_updated';
+    public const MSG_FAILED_CREATED = 'cropper_failed_created';
+    public const MSG_FAILED_UPDATED = 'cropper_failed_updated';
 
-    /**
-     * @var Zebra_Image
-     */
     private Zebra_Image $zebraImage; // Use the imported class
 
-    /**
-     * @var string
-     */
     private string $originalFilename;
 
-    /**
-     * @var string
-     */
     private string $tempFilename;
 
-    /**
-     * @var string
-     */
     private string $filename;
 
-    /**
-     * @var string
-     */
     private string $category;
 
-    /**
-     * @var bool
-     */
     private bool $update;
 
-    /**
-     * @var array
-     */
     private array $parameter;
 
     /**
-     * @param array $parameter
-     * @throws \InvalidArgumentException
+     * @throws InvalidArgumentException
      */
     public function __construct(array $parameter = [])
     {
@@ -90,14 +77,13 @@ class CropperExecutor
         }
 
         if (empty($this->originalFilename)) {
-            throw new \InvalidArgumentException("'media_name' parameter is required.");
+            throw new InvalidArgumentException("'media_name' parameter is required.");
         }
     }
 
     /**
-     * @return rex_media|null
      * @throws CroppingException
-     * @throws \rex_sql_exception
+     * @throws rex_sql_exception
      */
     private function mediaWriteInitial(): ?rex_media
     {
@@ -118,7 +104,7 @@ class CropperExecutor
 
             $return = rex_mediapool_saveMedia($FILE, $this->category, ['title' => ''], rex::getUser()->getValue('login'), false);
 
-            if ($return['ok'] == 1) {
+            if (1 == $return['ok']) {
                 $media = rex_media::get($this->tempFilename);
                 if ($media instanceof rex_media && rename(rex_path::media($this->tempFilename), rex_path::media($this->filename))) {
                     $sql = rex_sql::factory();
@@ -129,8 +115,8 @@ class CropperExecutor
                     $sql->addGlobalUpdateFields(rex::getUser()->getValue('login'));
                     $sql->update();
 
-                    if(rex_media::get($this->filename) instanceof rex_media) {
-                        return rex_media::get($this->filename); //Safe return
+                    if (rex_media::get($this->filename) instanceof rex_media) {
+                        return rex_media::get($this->filename); // Safe return
                     }
                 }
             }
@@ -140,7 +126,6 @@ class CropperExecutor
     }
 
     /**
-     * @return array
      * @throws CroppingException
      */
     public function crop(): array
@@ -156,18 +141,17 @@ class CropperExecutor
         $zebraErrors = [];
 
         // flip image
-        if ($this->parameter['scaleX'] == -1 && $this->parameter['scaleY'] == 1) {
+        if (-1 == $this->parameter['scaleX'] && 1 == $this->parameter['scaleY']) {
             $this->zebraImage->flip_horizontal();
-        } else if ($this->parameter['scaleX'] == 1 && $this->parameter['scaleY'] == -1) {
+        } elseif (1 == $this->parameter['scaleX'] && -1 == $this->parameter['scaleY']) {
             $this->zebraImage->flip_vertical();
-        } else if ($this->parameter['scaleX'] == -1 && $this->parameter['scaleY'] == -1) {
+        } elseif (-1 == $this->parameter['scaleX'] && -1 == $this->parameter['scaleY']) {
             $this->zebraImage->flip_both();
         }
         $zebraErrors[] = $this->zebraImage->error; // Capture errors *after* all flip operations
 
-
         // rotate image
-        if ($this->parameter['rotate'] != 0) {
+        if (0 != $this->parameter['rotate']) {
             $this->zebraImage->rotate($this->parameter['rotate']);
             $zebraErrors[] = $this->zebraImage->error; // Capture errors
         }
@@ -177,14 +161,14 @@ class CropperExecutor
             $this->zebraImage->crop(
                 $this->parameter['x'],
                 $this->parameter['y'],
-                ($this->parameter['x'] + $this->parameter['width']),
-                ($this->parameter['y'] + $this->parameter['height'])
+                $this->parameter['x'] + $this->parameter['width'],
+                $this->parameter['y'] + $this->parameter['height'],
             );
             $zebraErrors[] = $this->zebraImage->error; // Capture errors
         }
-        //These two lines did nothing useful, and were not used anywhere
-        //$imgwidth=$this->parameter['width'];
-        //$imgheight=$this->parameter['height'];
+        // These two lines did nothing useful, and were not used anywhere
+        // $imgwidth=$this->parameter['width'];
+        // $imgheight=$this->parameter['height'];
 
         rex_media_cache::delete($media->getFileName());
         rex_media_manager::deleteCache(pathinfo($media->getFileName(), PATHINFO_FILENAME));
@@ -199,13 +183,13 @@ class CropperExecutor
         $result = rex_mediapool_updateMedia(['name' => 'none'], $FILEINFOS, rex::getUser()->getValue('login'));
         $msgType = ($this->update) ? self::MSG_SUCCESSFUL_UPDATED : self::MSG_SUCCESSFUL_CREATED;
 
-        if (isset($result['ok']) && $result['ok'] == 1 && isset($result['filename'])) {
+        if (isset($result['ok']) && 1 == $result['ok'] && isset($result['filename'])) {
             $media = rex_media::get($result['filename']);
             $msg = $msgType;
             $ok = true;
 
             $size = getimagesize($this->zebraImage->target_path);
-            if ($size !== false) {
+            if (false !== $size) {
                 $sql = rex_sql::factory();
                 $sql->setTable(rex::getTable('media'));
                 $sql->setWhere(['filename' => $result['filename']]);
@@ -213,12 +197,10 @@ class CropperExecutor
                 $sql->setValue('width', $size[0]);
                 $sql->setValue('height', $size[1]);
                 $sql->update();
-            } else {
-                // Handle the error - maybe log it
-                // rex_logger::logError(E_WARNING, 'Could not get image size for ' . $this->zebraImage->target_path);
-                // Optionally set width/height to 0 or some default
             }
-
+            // Handle the error - maybe log it
+            // rex_logger::logError(E_WARNING, 'Could not get image size for ' . $this->zebraImage->target_path);
+            // Optionally set width/height to 0 or some default
         } else {
             $msg = ($this->update) ? self::MSG_FAILED_UPDATED : self::MSG_FAILED_CREATED;
             $ok = false;
@@ -229,7 +211,7 @@ class CropperExecutor
             'error' => array_filter($zebraErrors), // Filter out empty error codes
             'msg' => $msg,
             'ok' => $ok,
-            'update' => $this->update
+            'update' => $this->update,
         ];
     }
 }

--- a/lib/Cropper/CroppingException.php
+++ b/lib/Cropper/CroppingException.php
@@ -1,14 +1,13 @@
 <?php
+
 /**
  * User: joachimdoerr
  * Date: 2019-02-17
- * Time: 11:24
+ * Time: 11:24.
  */
 
-namespace Cropper;
+namespace FriendsOfRedaxo\Cropper\Cropper;
 
+use Exception;
 
-class CroppingException extends \Exception
-{
-
-}
+class CroppingException extends Exception {}

--- a/lib/deprecated/CropperExecutor.php
+++ b/lib/deprecated/CropperExecutor.php
@@ -1,6 +1,8 @@
 <?php
 
+namespace Cropper;
+
 /**
  * @deprecated Use FriendsOfRedaxo\Cropper\Cropper\CropperExecutor instead
  */
-class CropperExecutor extends FriendsOfRedaxo\Cropper\Cropper\CropperExecutor {}
+class CropperExecutor extends \FriendsOfRedaxo\Cropper\Cropper\CropperExecutor {}

--- a/lib/deprecated/CropperExecutor.php
+++ b/lib/deprecated/CropperExecutor.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @deprecated Use FriendsOfRedaxo\Cropper\Cropper\CropperExecutor instead
+ */
+class CropperExecutor extends FriendsOfRedaxo\Cropper\Cropper\CropperExecutor {}

--- a/lib/deprecated/CroppingException.php
+++ b/lib/deprecated/CroppingException.php
@@ -1,6 +1,8 @@
 <?php
 
+namespace Cropper;
+
 /**
  * @deprecated Use FriendsOfRedaxo\Cropper\Cropper\CroppingException instead
  */
-class CroppingException extends FriendsOfRedaxo\Cropper\Cropper\CroppingException {}
+class CroppingException extends \FriendsOfRedaxo\Cropper\Cropper\CroppingException {}

--- a/lib/deprecated/CroppingException.php
+++ b/lib/deprecated/CroppingException.php
@@ -1,0 +1,6 @@
+<?php
+
+/**
+ * @deprecated Use FriendsOfRedaxo\Cropper\Cropper\CroppingException instead
+ */
+class CroppingException extends FriendsOfRedaxo\Cropper\Cropper\CroppingException {}

--- a/pages/mediapool.cropper.php
+++ b/pages/mediapool.cropper.php
@@ -1,20 +1,21 @@
 <?php
+
 /**
  * Author: Joachim Doerr
  * Date: 2019-02-15
- * Time: 12:04
+ * Time: 12:04.
  */
 
-use Cropper\CropperExecutor;
-use Cropper\CroppingException;
+use FriendsOfRedaxo\Cropper\Cropper\CropperExecutor;
+use FriendsOfRedaxo\Cropper\Cropper\CroppingException;
 
 const POOL_MEDIA = 'mediapool/media';
 
 $csrf = rex_csrf_token::factory('mediapool_structure');
 
-$allowedExtensions = array('jpg' => array('jpg', 'jpeg'), 'png' => array('png'), 'gif' => array('gif'));
+$allowedExtensions = ['jpg' => ['jpg', 'jpeg'], 'png' => ['png'], 'gif' => ['gif']];
 $mediaName = rex_request::request('media_name', 'string', null);
-$urlParameter = array('file_id' => rex_request::request('file_id', 'integer'), 'rex_file_category' => rex_request::request('rex_file_category', 'integer'));
+$urlParameter = ['file_id' => rex_request::request('file_id', 'integer'), 'rex_file_category' => rex_request::request('rex_file_category', 'integer')];
 
 $body = '';
 $title = '';
@@ -27,8 +28,7 @@ if (!rex::getUser()->hasPerm('cropper[]')) {
 }
 
 try {
-    if (rex_request::request('btn_save', 'integer', 0) === 1) {
-
+    if (1 === rex_request::request('btn_save', 'integer', 0)) {
         if (!$csrf->isValid()) {
             throw new CroppingException('EXCEPTION csrf not valide'); // TODO text!
         }
@@ -53,7 +53,7 @@ try {
         }
     }
 
-    if (rex_request::request('btn_abort', 'integer', 0) === 1) {
+    if (1 === rex_request::request('btn_abort', 'integer', 0)) {
         rex_response::sendRedirect(rex_url::backendPage(POOL_MEDIA, $urlParameter, false));
     }
 
@@ -63,22 +63,21 @@ try {
     if (rex_addon::exists('media_manager') && !rex_addon::get('media_manager')->isAvailable()) {
         throw new CroppingException('EXCEPTION error MSG media_manager must be active'); // TODO text!
     }
-    if (is_null($mediaName)) {
+    if (null === $mediaName) {
         throw new CroppingException('EXCEPTION! NO NAME!'); // TODO text!
     }
     if (!$media = rex_media::get($mediaName)) {
         throw new CroppingException('EXCEPTION! NO MEDIA OBJ'); // TODO text!
     }
     if ($media instanceof rex_media && rex_media::isImageType(rex_file::extension($mediaName))) {
-
-        $formElements = array();
+        $formElements = [];
         $panel = '';
-        $options = array();
+        $options = [];
 
         $title = sprintf(rex_i18n::msg('cropper_media_crop_title'), pathinfo($media->getFileName(), PATHINFO_FILENAME));
 
-        $pngIn = ($media->getExtension() == 'png' && rex::getUser()->isAdmin()) ? ' in' : '';
-        $jpgIn = (($media->getExtension() == 'jpg' or $media->getExtension() == 'jpeg') && rex::getUser()->isAdmin()) ? ' in' : '';
+        $pngIn = ('png' == $media->getExtension() && rex::getUser()->isAdmin()) ? ' in' : '';
+        $jpgIn = (('jpg' == $media->getExtension() || 'jpeg' == $media->getExtension()) && rex::getUser()->isAdmin()) ? ' in' : '';
 
         $jpgQuality = rex_request::request('jpg_quality', 'integer', 100);
         $pngCompression = rex_request::request('png_compression', 'integer', 9);
@@ -86,24 +85,24 @@ try {
         $newFileName = rex_request::request('new_file_name', 'string', rex_escape(pathinfo($media->getFileName(), PATHINFO_FILENAME)));
         $newMediaPoolCategory = rex_request::request('rex_file_category', 'integer', null);
 
-        $allowed = (is_null($newFileExtension)) ? false : true;
+        $allowed = (null === $newFileExtension) ? false : true;
 
         // img type options and check is possible to use for my media file
         foreach ($allowedExtensions as $item => $ass) {
             $selected = '';
-            if (in_array($media->getExtension(), $ass) && is_null($newFileExtension)) {
+            if (in_array($media->getExtension(), $ass) && null === $newFileExtension) {
                 $selected = 'selected="selected"';
                 $allowed = true;
             }
-            if (!is_null($newFileExtension) && in_array($newFileExtension, $ass)) {
+            if (null !== $newFileExtension && in_array($newFileExtension, $ass)) {
                 $selected = 'selected="selected"';
-                if ($item == 'jpg') {
+                if ('jpg' == $item) {
                     $pngIn = '';
                     $jpgIn = ' in';
-                } else if ($item == 'png') {
+                } elseif ('png' == $item) {
                     $pngIn = ' in';
                     $jpgIn = '';
-                } else if ($item == 'gif') {
+                } elseif ('gif' == $item) {
                     $pngIn = '';
                     $jpgIn = '';
                 }
@@ -117,30 +116,28 @@ try {
 
         $mtime = @filemtime(rex_url::media($mediaName)) . uniqid();
 
-
         $fragment = new rex_fragment();
         $fragment->setVar('mediaUrl', rex_url::media($mediaName));
         $fragment->setVar('media', $media);
         $fragment->setVar('mtime', $mtime);
         $panel = $fragment->parse('cropper_panel.php');
 
-
         // JPG QUALITY
         $fragment = new rex_fragment();
-        $fragment->setVar('elements', array(array(
+        $fragment->setVar('elements', [[
             'class' => 'rex-range-input-group',
             'left' => '<input id="rex-js-rating-source-jpg-quality" type="range" min="0" max="100" step="1" value="' . $jpgQuality . '" />',
             'field' => '<input class="form-control" id="rex-js-rating-text-jpg-quality" type="text" name="jpg_quality" value="' . $jpgQuality . '" />',
-        )), false);
+        ]], false);
         $jpgQualityElement = $fragment->parse('core/form/input_group.php');
 
         // PNG COMPRESSION
         $fragment = new rex_fragment();
-        $fragment->setVar('elements', array(array(
+        $fragment->setVar('elements', [[
             'class' => 'rex-range-input-group',
             'left' => '<input id="rex-js-rating-source-png-compression" type="range" min="0" max="9" step="1" value="' . $pngCompression . '" />',
             'field' => '<input class="form-control" id="rex-js-rating-text-png-compression" type="text" name="png_compression" value="' . $pngCompression . '" />',
-        )), false);
+        ]], false);
         $pngCompressionElement = $fragment->parse('core/form/input_group.php');
 
         // FORM ELEMENTS
@@ -150,40 +147,38 @@ try {
                 <input type="checkbox" name="create_new_image" id="create_new_image" checked />
             <span></span>' . rex_i18n::msg('cropper_img_save_info') . '</label>';
         if (!rex::getUser()->hasPerm('cropper[overwrite]')) :
-            $checkbox =  '<div class="nocheckbox"><input type="hidden" name="create_new_image" value="1" />' . rex_i18n::msg('cropper_img_save_info_nochoice') .'</div>';
+            $checkbox = '<div class="nocheckbox"><input type="hidden" name="create_new_image" value="1" />' . rex_i18n::msg('cropper_img_save_info_nochoice') . '</div>';
         endif;
         $fragment = new rex_fragment();
-        $fragment->setVar('elements', array(
-            array(
+        $fragment->setVar('elements', [
+            [
                 'label' => '<label for="rex-mediapool-title">' . rex_i18n::msg('cropper_save_options') . '</label>',
                 'field' => $checkbox,
-            ),
-        ), false);
+            ],
+        ], false);
         $panel .= $fragment->parse('core/form/form.php');
 
         // FILENAME
         $fragment = new rex_fragment();
-        $fragment->setVar('elements', array(
-            array(
+        $fragment->setVar('elements', [
+            [
                 'label' => '<label for="rex-mediapool-title">' . rex_i18n::msg('pool_filename') . '</label>',
-//                'field' => '<div class="input-group">
-//                            <input class="form-control" type="text" name="new_file_name" value="' . $newFileName . '" />
-//                            <select name="new_file_extension" class="selectpicker" readonly="readonly">' . implode("\n", $options) . '</select>
-//                        </div>',
+                //                'field' => '<div class="input-group">
+                //                            <input class="form-control" type="text" name="new_file_name" value="' . $newFileName . '" />
+                //                            <select name="new_file_extension" class="selectpicker" readonly="readonly">' . implode("\n", $options) . '</select>
+                //                        </div>',
                 'field' => '<div class="input-group">
                                 <input class="form-control" type="text" name="new_file_name" value="' . $newFileName . '" />
                                 <input type="hidden" name="new_file_extension" value="' . $media->getExtension() . '" />
                                 <span class="input-group-addon">' . $media->getExtension() . '</span>
                             </div>',
-            ),
-        ), false);
-
+            ],
+        ], false);
 
         // Medienpool-Kategorien zur Auswahl
         $rex_file_category = $media->getCategoryId();
         $PERMALL = rex::getUser()->getComplexPerm('media')->hasCategoryPerm(0);
-        if (!$PERMALL && !rex::getUser()->getComplexPerm('media')->hasCategoryPerm($rex_file_category))
-        {
+        if (!$PERMALL && !rex::getUser()->getComplexPerm('media')->hasCategoryPerm($rex_file_category)) {
             $rex_file_category = 0;
         }
         $cats_sel = new rex_media_category_select();
@@ -198,44 +193,44 @@ try {
         $mediacat_select = '
         <dl class="rex-form-group form-group">
                         <dt>
-                            <label for="rex-mediapool-category">'. rex_i18n::msg('pool_file_category') .'</label>
+                            <label for="rex-mediapool-category">' . rex_i18n::msg('pool_file_category') . '</label>
                         </dt>
                         <dd>
-                            ' . $cats_sel->get() .'
+                            ' . $cats_sel->get() . '
                         </dd>
                     </dl>';
 
-        $panel .= "<div id=\"new_file_name\" class=\"collapse in\">" . $fragment->parse('core/form/form.php') . $mediacat_select ."</div>";
+        $panel .= '<div id="new_file_name" class="collapse in">' . $fragment->parse('core/form/form.php') . $mediacat_select . '</div>';
 
         // FORM ELEMENTS
         // JPG QUALITY
         $fragment = new rex_fragment();
-        $fragment->setVar('elements', array(
-            array(
+        $fragment->setVar('elements', [
+            [
                 'label' => '<label for="rex-mediapool-title">' . rex_i18n::msg('cropper_jpg_quality') . '</label>',
                 'field' => $jpgQualityElement,
-            ),
-        ), false);
+            ],
+        ], false);
         $panel .= "<div class=\"collapse $jpgIn\">" . $fragment->parse('core/form/form.php') . '</div>';
 
         // FORM ELEMENTS
         // PNG COMPRESSION
         $fragment = new rex_fragment();
-        $fragment->setVar('elements', array(
-            array(
+        $fragment->setVar('elements', [
+            [
                 'label' => '<label for="rex-mediapool-title">' . rex_i18n::msg('cropper_png_compression') . '</label>',
                 'field' => $pngCompressionElement,
-            ),
-        ), false);
+            ],
+        ], false);
         $panel .= "<div class=\"collapse $pngIn\">" . $fragment->parse('core/form/form.php') . '</div>';
 
         // FORM FOOTER
         // BUTTONS
         $fragment = new rex_fragment();
-        $fragment->setVar('elements', array(
-            array('field' => '<button class="btn btn-apply rex-form-aligned" type="submit" value="1" name="btn_save">' . rex_i18n::msg('form_save') . '</button>'),
-            array('field' => '<button class="btn btn-abort" type="submit" value="1" name="btn_abort">' . rex_i18n::msg('form_abort') . '</button>'),
-        ), false);
+        $fragment->setVar('elements', [
+            ['field' => '<button class="btn btn-apply rex-form-aligned" type="submit" value="1" name="btn_save">' . rex_i18n::msg('form_save') . '</button>'],
+            ['field' => '<button class="btn btn-abort" type="submit" value="1" name="btn_abort">' . rex_i18n::msg('form_abort') . '</button>'],
+        ], false);
         $buttons = $fragment->parse('core/form/submit.php');
 
         // FINAL BODY CREATION


### PR DESCRIPTION
Vorschlag für die Umstellung des Namespace von `Cropper`auf `FriendsOfRedaxo\Cropper`.

- Es sind nur wenige Anpassungen nötig. 
- Die Verzeichnisstruktur habe ich beibehalten. Daher sind die beiden Cropp-Klassen tatsächlich im Namespace `FriendsOfRedaxo\Cropper\Cropper`, die sie in einem Unterverzeichnis `lib/Cropper` liegen.
- Es gibt Hilfsklassen im alten Namespace mit deprecated-Vermerk
- Keine Änderungen in der Readme, da dert die Klassen nicht erwähnt werden.

Hinweis: 
https://github.com/FriendsOfREDAXO/cropper/blob/0c3eb9421779db29921f80c352bf24180aaa6546/lib/Cropper/CropperExecutor.php#L19
Diese Definition der Exception-Klasse ist sozusagen ein Duplikat zum Inhalt der Datei **CroppingException.php**. Das habe ich nicht aufgeräumt und wäre m.E. Teil weiterer Bereinigungen (es gibt so dies und das) abseits des Namespace-Themas 